### PR TITLE
fix: Handle None values in visualization fields (x_pred, sigma, t)

### DIFF
--- a/spatialreasoners/benchmark/evaluation/frame_vis_sampling_evaluation/image_sampling_evaluation/image_sampling_evaluation.py
+++ b/spatialreasoners/benchmark/evaluation/frame_vis_sampling_evaluation/image_sampling_evaluation/image_sampling_evaluation.py
@@ -68,7 +68,7 @@ class ImageSamplingEvaluation(FrameVisSamplingEvaluation[T]):
             assert "t" in unstructured, "t should always be in inference batch"
             image = hcat(image, (1 - unstructured["t"]).expand_as(image))
 
-        if "sigma" in unstructured:
+        if unstructured.get("sigma") is not None:
             sigma = unstructured["sigma"].squeeze(1)
             mask = sigma == 0  # mask out regions with no uncertainty
 
@@ -82,13 +82,13 @@ class ImageSamplingEvaluation(FrameVisSamplingEvaluation[T]):
             sigma_color.masked_fill_(mask.unsqueeze(1), 1)
             image = hcat(image.expand(-1, 3, -1, -1), sigma_color)
 
-        if "x_pred" in unstructured:
+        if unstructured.get("x_pred") is not None:
             x = (unstructured["x_pred"] + 1) / 2
             if x.size(1) == 4:
                 x = x[:, :3] * x[:, 3:]
             image = hcat(image, x.expand(-1, image.shape[1], -1, -1))
 
-        if any(k in unstructured for k in ("t", "sigma", "x_pred")):
+        if any(unstructured.get(k) is not None for k in ("t", "sigma", "x_pred")):
             image = add_border(image)
 
         return prep_images(image, channel_last=False)

--- a/spatialreasoners/benchmark/evaluation/frame_vis_sampling_evaluation/image_sampling_evaluation/image_sampling_evaluation.py
+++ b/spatialreasoners/benchmark/evaluation/frame_vis_sampling_evaluation/image_sampling_evaluation/image_sampling_evaluation.py
@@ -65,7 +65,7 @@ class ImageSamplingEvaluation(FrameVisSamplingEvaluation[T]):
             image = image[:, :3] * image[:, 3:]
 
         if self.cfg.visualize_time:
-            assert "t" in unstructured, "t should always be in inference batch"
+            assert unstructured.get("t") is not None, "t should always be in inference batch"
             image = hcat(image, (1 - unstructured["t"]).expand_as(image))
 
         if unstructured.get("sigma") is not None:


### PR DESCRIPTION
## Description
The issue was that disabling `visualize_x` in the config caused `x_pred` to be `None`. The visualization code in `spatialreasoners` checked for the existence of the key "x_pred" (which was still present as `None`) rather than checking if the value was valid.

I updated [image_sampling_evaluation.py](cci:7://file:///Users/elgawad/Library/CloudStorage/OneDrive-Universit%C3%A4tdesSaarlandes/Masters/M.Sc.%20Computer%20Science%20%20Saarland%20Uni/WS%202025-2026/Thesis/Repos/spatialreasoners/spatialreasoners/benchmark/evaluation/frame_vis_sampling_evaluation/image_sampling_evaluation/image_sampling_evaluation.py:0:0-0:0) to fix this check by ensuring values are not `None` before processing. This fix was applied to `x_pred`, `sigma`, and `t` to ensure robustness across all visualization fields.

## Changes
- Replaced direct key checks (e.g., `if "x_pred" in unstructured`) with validity checks (e.g., `if unstructured.get("x_pred") is not None`).
- Updated assertion for `t` to ensure it is not `None` (e.g., `assert unstructured.get("t") is not None`).